### PR TITLE
Add command object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,8 @@ set(SOURCES
     src/port.c
     src/object/command.c
     src/protocol/decode_call.c
-    src/protocol/enum.c)
+    src/protocol/enum.c
+    src/protocol/event.c)
 
 # build
 project(bacnetd)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,8 @@ set(SOURCES
     src/main.c
     src/port.c
     src/protocol/decode_call.c
-    src/protocol/enum.c)
+    src/protocol/enum.c
+    src/object/command.c)
 
 # build
 project(bacnetd)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,25 +52,26 @@ CPMFindPackage(
     PATCHES ${PATCHES})
 
 # setup erlang
-set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} $ENV{ERL_EI_LIBDIR})
-find_library(ERLANG_EI_LIB ei)
-include_directories($ENV{ERL_EI_INCLUDE_DIR})
+find_library(libei NAMES ei HINTS $ENV{ERL_EI_LIBDIR} REQUIRED)
 
 # sources
-INCLUDE_DIRECTORIES(src/)
 set(SOURCES
     src/bacnet.c
     src/log.c
     src/main.c
     src/port.c
+    src/object/command.c
     src/protocol/decode_call.c
-    src/protocol/enum.c
-    src/object/command.c)
+    src/protocol/enum.c)
 
 # build
 project(bacnetd)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_DIR})
 add_executable(bacnetd ${SOURCES})
-set_target_properties(bacnetd PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY_RELEASE $ENV{MIX_APP_PATH}/priv)
-target_link_libraries(bacnetd PRIVATE bacnet-stack ${ERLANG_EI_LIB})
+
+target_include_directories(bacnetd
+    PRIVATE
+        $ENV{ERL_EI_INCLUDE_DIR}
+        src/)
+
+target_link_libraries(bacnetd PRIVATE bacnet-stack ${libei})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20.0 FATAL_ERROR)
 
 # dependency manager
-set(CPM_VERSION 0.40.2)
+set(CPM_VERSION 0.40.5)
 set(CPM_SOURCE_CACHE ${CMAKE_CURRENT_SOURCE_DIR}/_build/cache/cpm)
 set(CPM_USE_NAMED_CACHE_DIRECTORIES false)
 set(CPM_PATH "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_VERSION}.cmake")

--- a/lib/bacnet.ex
+++ b/lib/bacnet.ex
@@ -74,7 +74,7 @@ defmodule BACNet do
     case maybe_message do
       {:log, level, message} -> Logger.log(level, message)
       {:"$gen_reply", to, result} -> GenServer.reply(to, result)
-      {:"$gen_cast", message} -> GenServer.cast(state.owner, message)
+      {:"$event", message} -> send(state.owner, message)
       {:error, :invalid_term, data} -> Logger.warning("Received bad data #{inspect(data)}")
     end
 

--- a/lib/bacnet.ex
+++ b/lib/bacnet.ex
@@ -10,7 +10,10 @@ defmodule BACNet do
   defmodule State do
     @doc false
 
-    defstruct [:port]
+    defstruct [
+      :owner,
+      :port,
+    ]
   end
 
   @doc """
@@ -18,12 +21,14 @@ defmodule BACNet do
   """
   @spec start_link(any, GenServer.options()) :: GenServer.on_start()
   def start_link(args, opts \\ []) do
+    args = Keyword.put_new(args, :owner, self())
+
     GenServer.start_link(__MODULE__, args, opts)
   end
 
   @impl GenServer
   def init(args) do
-    bacnetd_exe = "#{:code.priv_dir(:bacnet)}/bacnetd"
+    bacnetd_exe = Path.join(:code.priv_dir(:bacnet), "bacnetd")
 
     env =
       [
@@ -41,7 +46,10 @@ defmodule BACNet do
         [:binary, :use_stdio, packet: 4, env: env]
       )
 
-    state = %State{port: port}
+    state = %State{
+      owner: args[:owner],
+      port: port,
+    }
 
     {:ok, state}
   end
@@ -56,26 +64,20 @@ defmodule BACNet do
 
   @impl GenServer
   def handle_info({_port, {:data, data}}, state) do
-    try do
-      data
-      |> :erlang.binary_to_term
-      |> process_message
-    catch
-      _ -> nil
+    maybe_message =
+      try do
+        :erlang.binary_to_term(data)
+      rescue
+        _ -> {:error, :invalid_term, data}
+      end
+
+    case maybe_message do
+      {:log, level, message} -> Logger.log(level, message)
+      {:"$gen_reply", to, result} -> GenServer.reply(to, result)
+      {:"$gen_cast", message} -> GenServer.cast(state.owner, message)
+      {:error, :invalid_term, data} -> Logger.warning("Received bad data #{inspect(data)}")
     end
 
     {:noreply, state}
-  end
-
-  defp process_message({:log, level, message}) do
-    Logger.log(level, message)
-  end
-
-  defp process_message({:"$gen_reply", to, result}) do
-    GenServer.reply(to, result)
-  end
-
-  defp process_message(unknown) do
-    Logger.warning("Unknown message received #{inspect(unknown)}")
   end
 end

--- a/lib/bacnet/gateway/object.ex
+++ b/lib/bacnet/gateway/object.ex
@@ -65,6 +65,7 @@ defmodule BACNet.Gateway.Object do
     - `device_id`: The ID of the BACnet device where the object will be created.
     - `object_id`: The unique ID for the new multistate input object.
     - `name`: A unique name for the object.
+    - `states`: A set of strings representing the object's states.
   """
   @spec create_multistate_input(
     pid       :: pid,
@@ -106,5 +107,53 @@ defmodule BACNet.Gateway.Object do
       object_id,
       value,
     })
+  end
+
+  @doc """
+  Creates a new command object.
+
+  ## Parameters
+
+    - `pid`: The PID of the GenServer managing BACnet communications.
+    - `device_id`: The ID of the BACnet device where the object will be created.
+    - `object_id`: The unique ID for the new command object.
+    - `name`: A unique name for the object.
+    - `description`: A short description for the command object.
+  """
+  @spec create_command(
+    pid         :: pid,
+    device_id   :: integer,
+    object_id   :: integer,
+    name        :: String.t,
+    description :: String.t
+  ) :: :ok | {:error, term}
+  def create_command(pid, device_id, object_id, name, description) do
+    GenServer.call(pid, {
+      :create_routed_command,
+      device_id,
+      object_id,
+      name,
+      description,
+    })
+  end
+
+  @doc """
+  Set the status of an active command.
+
+  ## Parameters
+
+    - `pid`: The PID of the GenServer managing BACnet communications.
+    - `device_id`: The ID of the BACnet device where the object will be created.
+    - `object_id`: The unique ID for the new command object.
+    - `status`: The status of the command.
+  """
+  @spec set_command_status(
+    pid       :: pid,
+    device_id :: integer,
+    object_id :: integer,
+    status     :: :succeeded | :failed
+  ) :: :ok | {:error, term}
+  def set_command_status(pid, device_id, object_id, status) do
+    GenServer.call(pid, {:set_command_status, device_id, object_id, status})
   end
 end

--- a/lib/bacnet/gateway/object.ex
+++ b/lib/bacnet/gateway/object.ex
@@ -125,15 +125,17 @@ defmodule BACNet.Gateway.Object do
     device_id   :: integer,
     object_id   :: integer,
     name        :: String.t,
-    description :: String.t
+    description :: String.t,
+    value       :: nil | non_neg_integer
   ) :: :ok | {:error, term}
-  def create_command(pid, device_id, object_id, name, description) do
+  def create_command(pid, device_id, object_id, name, description, value \\ nil) do
     GenServer.call(pid, {
       :create_routed_command,
       device_id,
       object_id,
       name,
       description,
+      value
     })
   end
 

--- a/lib/bacnet/gateway/object.ex
+++ b/lib/bacnet/gateway/object.ex
@@ -154,6 +154,11 @@ defmodule BACNet.Gateway.Object do
     status     :: :succeeded | :failed
   ) :: :ok | {:error, term}
   def set_command_status(pid, device_id, object_id, status) do
-    GenServer.call(pid, {:set_command_status, device_id, object_id, status})
+    GenServer.call(pid, {
+      :set_routed_command_status,
+      device_id,
+      object_id,
+      status
+    })
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,7 @@ defmodule BACNet.MixProject do
       deps: deps(),
       docs: docs(),
       compilers: [:cmake] ++ Mix.compilers(),
+      cmake_env: %{"MAKEFLAGS" => "-j#{nproc()}"},
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls, test_task: "espec"],
       dialyzer: [
@@ -99,5 +100,9 @@ defmodule BACNet.MixProject do
     [Mix.Project.build_path(), "plt", "dialyxir.plt"]
     |> Path.join()
     |> Path.expand()
+  end
+
+  defp nproc do
+    :erlang.system_info(:logical_processors)
   end
 end

--- a/src/bacnet.c
+++ b/src/bacnet.c
@@ -531,7 +531,9 @@ static int handle_create_routed_command(create_routed_command_t* params)
       device,
       params->object_bacnet_id,
       params->name,
-      params->description
+      params->description,
+      params->value,
+      params->in_progress
     );
 
   if (bacnet_id != params->object_bacnet_id)

--- a/src/bacnet.c
+++ b/src/bacnet.c
@@ -12,6 +12,7 @@
 #include "bacnet.h"
 #include "log.h"
 #include "protocol/decode_call.h"
+#include "object/command.h"
 
 #define REPLY_OK(reply) \
   ei_x_encode_atom(reply, "ok")
@@ -269,6 +270,28 @@ static object_functions_t SUPPORTED_OBJECT_TABLE[] = {
     .Object_Remove_List_Element = NULL,
     .Object_Create = Routed_Multistate_Input_Create,
     .Object_Delete = Routed_Multistate_Input_Delete,
+    .Object_Timer = NULL,
+  },
+  {
+    .Object_Type = OBJECT_COMMAND,
+    .Object_Init = command_init,
+    .Object_Count = command_count,
+    .Object_Index_To_Instance = command_index_to_instance,
+    .Object_Valid_Instance = command_valid_instance,
+    .Object_Name = command_object_name,
+    .Object_Read_Property = command_read_property,
+    .Object_Write_Property = command_write_property,
+    .Object_RPM_List = command_property_lists,
+    .Object_RR_Info = NULL,
+    .Object_Iterator = NULL,
+    .Object_Value_List = NULL,
+    .Object_COV = NULL,
+    .Object_COV_Clear = NULL,
+    .Object_Intrinsic_Reporting = NULL,
+    .Object_Add_List_Element = NULL,
+    .Object_Remove_List_Element = NULL,
+    .Object_Create = NULL,
+    .Object_Delete = NULL,
     .Object_Timer = NULL,
   },
 };

--- a/src/bacnet.c
+++ b/src/bacnet.c
@@ -278,7 +278,7 @@ static object_functions_t SUPPORTED_OBJECT_TABLE[] = {
     .Object_Count = command_count,
     .Object_Index_To_Instance = command_index_to_instance,
     .Object_Valid_Instance = command_valid_instance,
-    .Object_Name = command_object_name,
+    .Object_Name = command_name,
     .Object_Read_Property = command_read_property,
     .Object_Write_Property = command_write_property,
     .Object_RPM_List = command_property_lists,
@@ -507,6 +507,41 @@ handle_set_routed_multistate_value(set_routed_multistate_input_value_t* params)
     params->object_bacnet_id,
     params->value
   );
+
+  Get_Routed_Device_Object(0);
+
+  return 0;
+}
+
+static int handle_create_routed_command(create_routed_command_t* params)
+{
+  uint32_t device_index =
+    Routed_Device_Instance_To_Index(params->device_bacnet_id);
+
+  DEVICE_OBJECT_DATA* device = Get_Routed_Device_Object(device_index);
+
+  uint32_t bacnet_id =
+    command_create(device, params->object_bacnet_id, params->name);
+
+  if (bacnet_id != params->object_bacnet_id)
+    return -1;
+
+  Get_Routed_Device_Object(0);
+
+  return 0;
+}
+
+static int handle_set_routed_command_status(set_routed_command_status_t* params)
+{
+  uint32_t device_index =
+    Routed_Device_Instance_To_Index(params->device_bacnet_id);
+
+  DEVICE_OBJECT_DATA* device = Get_Routed_Device_Object(device_index);
+  COMMAND_OBJECT*     object = Keylist_Data(device->objects, params->object_bacnet_id);
+
+  if (!object) return -1;
+
+  command_update_status(object, params->status);
 
   Get_Routed_Device_Object(0);
 

--- a/src/object/command.c
+++ b/src/object/command.c
@@ -70,7 +70,9 @@ uint32_t command_create(
   DEVICE_OBJECT_DATA* device,
   uint32_t instance,
   char* name,
-  char* description
+  char* description,
+  uint32_t value,
+  bool in_progress
 ) {
   if (instance >= BACNET_MAX_INSTANCE)
     return BACNET_MAX_INSTANCE;
@@ -89,8 +91,8 @@ uint32_t command_create(
     return BACNET_MAX_INSTANCE;
 
   object->type          = OBJECT_COMMAND;
-  object->present_value = 0;
-  object->in_progress   = false;
+  object->present_value = value;
+  object->in_progress   = in_progress;
   object->successful    = true;
 
   memset(object->name, 0, sizeof(object->name));

--- a/src/object/command.c
+++ b/src/object/command.c
@@ -1,0 +1,109 @@
+#include <bacnet/bacdef.h>
+#include <bacnet/rp.h>
+#include <bacnet/wp.h>
+
+/**
+ * @brief Attempts to set required, optional and proprietary command properties.
+ *
+ * @note All params are sentinel terminated list of integers.
+ * @param required - BACnet required properties for a Command object.
+ * @param optional - BACnet optional properties for a Command object.
+ * @param proprietary - BACnet proprietary properties for a Command object.
+ */
+void command_property_lists(
+  const int **required,
+  const int **optional,
+  const int **proprietary
+) {
+  static const int required_list[] = {
+    PROP_OBJECT_IDENTIFIER,
+    PROP_OBJECT_NAME,
+    PROP_OBJECT_TYPE,
+    PROP_PRESENT_VALUE,
+    PROP_IN_PROCESS,
+    PROP_ALL_WRITES_SUCCESSFUL,
+    PROP_ACTION,
+    -1
+  };
+
+  static const int optional_list[] = { -1 };
+  static const int proprietary_list[] = { -1 };
+
+  if (required) *required = required_list;
+  if (optional) *optional = optional_list;
+  if (proprietary) *proprietary = proprietary_list;
+}
+
+/**
+ * @brief Initializes a Command object.
+ */
+void command_init(void)
+{
+  return;
+}
+
+/**
+ * @brief Returns the count of Command objects for the currently selected
+ *        Device.
+ */
+unsigned command_count(void)
+{
+  return -1;
+}
+
+/**
+ * @brief Get the Commands's instace number from its index.
+ *
+ * @param index - Index of Command object from within the Devices Object's list.
+ *
+ * @return BACnet Object instance number.
+ */
+uint32_t command_index_to_instance(unsigned index)
+{
+  return -1;
+}
+
+/**
+ * @brief Checks if the Object instance is a valid Command Object.
+ *
+ * @param instance - Object instance number.
+ */
+bool command_valid_instance(uint32_t instance)
+{
+  return false;
+}
+
+/**
+ * @brief Retrieve the name of a Command Object.
+ *
+ * @param[in] instance - Object instance number.
+ * @param[out] name - The Objects's name.
+ */
+bool command_object_name(uint32_t instance, BACNET_CHARACTER_STRING *name)
+{
+  return false;
+}
+
+/**
+ * @brief BACnet read-property handler for a Command Object.
+ *
+ * @param[out] data - Holds request and reply data.
+ *
+ * @return Byte count of the APDU or BACNET_STATUS_ERROR.
+ */
+int command_read_property(BACNET_READ_PROPERTY_DATA *data)
+{
+  return -1;
+}
+
+/**
+ * @brief BACnet write-property handler for a Command Object.
+ *
+ * @param[out] data - Holds request and reply data.
+ *
+ * @return true if no errors occur.
+ */
+bool command_write_property(BACNET_WRITE_PROPERTY_DATA *data)
+{
+  return false;
+}

--- a/src/object/command.c
+++ b/src/object/command.c
@@ -1,10 +1,6 @@
 #include <stdlib.h>
-#include <bacnet/bacdef.h>
-#include <bacnet/rp.h>
-#include <bacnet/wp.h>
 #include <bacnet/basic/object/device.h>
 #include <bacnet/basic/object/routed_object.h>
-#include <bacnet/basic/sys/keylist.h>
 
 #include "object/command.h"
 #include "protocol/event.h"
@@ -144,7 +140,7 @@ uint32_t command_index_to_instance(unsigned index)
  */
 bool command_valid_instance(uint32_t instance)
 {
-  DEVICE_OBJECT_DATA* device  = Get_Routed_Device_Object(-1);
+  DEVICE_OBJECT_DATA* device = Get_Routed_Device_Object(-1);
   COMMAND_OBJECT*     object = Keylist_Data(device->objects, instance);
 
   if (!object) return false;

--- a/src/object/command.h
+++ b/src/object/command.h
@@ -29,7 +29,9 @@ uint32_t command_create(
   DEVICE_OBJECT_DATA* device,
   uint32_t instance,
   char* name,
-  char* description);
+  char* description,
+  uint32_t value,
+  bool in_progress);
 
 bool command_update_status(COMMAND_OBJECT* object, bool successful);
 unsigned command_count(void);

--- a/src/object/command.h
+++ b/src/object/command.h
@@ -1,0 +1,18 @@
+#ifndef BACNET_OBJECT_COMMAND_H
+#define BACNET_OBJECT_COMMAND_H
+
+void command_init(void);
+unsigned command_count(void);
+uint32_t command_index_to_instance(unsigned index);
+bool command_valid_instance(uint32_t instance);
+bool command_object_name(uint32_t instance, BACNET_CHARACTER_STRING* name);
+bool command_name_set(uint32_t instance, char* name);
+int command_read_property(BACNET_READ_PROPERTY_DATA* data);
+bool command_write_property(BACNET_WRITE_PROPERTY_DATA* data);
+
+void command_property_lists(
+  const int** required,
+  const int** optional,
+  const int** proprietary);
+
+#endif /* BACNET_OBJECT_COMMAND_H */

--- a/src/object/command.h
+++ b/src/object/command.h
@@ -1,6 +1,27 @@
 #ifndef BACNET_OBJECT_COMMAND_H
 #define BACNET_OBJECT_COMMAND_H
 
+#include <bacnet/bacaction.h>
+
+#ifndef MAX_COMMAND_ACTIONS
+#define MAX_COMMAND_ACTIONS 8
+#endif
+
+#define MAX_OBJ_NAME_LEN 32
+#define MAX_OBJ_DESC_LEN 64
+
+typedef struct {
+  BACNET_OBJECT_TYPE type;
+
+  uint32_t present_value;
+  bool     in_progress;
+  bool     successful;
+  char     name[MAX_OBJ_NAME_LEN];
+  char     description[MAX_OBJ_DESC_LEN];
+
+  BACNET_ACTION_LIST actions[MAX_COMMAND_ACTIONS]; // TODO: make this dynamic?
+} COMMAND_OBJECT;
+
 void command_init(void);
 unsigned command_count(void);
 uint32_t command_index_to_instance(unsigned index);

--- a/src/object/command.h
+++ b/src/object/command.h
@@ -23,10 +23,12 @@ typedef struct {
 } COMMAND_OBJECT;
 
 void command_init(void);
+uint32_t command_create(DEVICE_OBJECT_DATA* device, uint32_t instance, char* name);
+bool command_update_status(COMMAND_OBJECT* object, bool successful);
 unsigned command_count(void);
 uint32_t command_index_to_instance(unsigned index);
 bool command_valid_instance(uint32_t instance);
-bool command_object_name(uint32_t instance, BACNET_CHARACTER_STRING* name);
+bool command_name(uint32_t instance, BACNET_CHARACTER_STRING* name);
 bool command_name_set(uint32_t instance, char* name);
 int command_read_property(BACNET_READ_PROPERTY_DATA* data);
 bool command_write_property(BACNET_WRITE_PROPERTY_DATA* data);

--- a/src/object/command.h
+++ b/src/object/command.h
@@ -19,11 +19,18 @@ typedef struct {
   char     name[MAX_OBJ_NAME_LEN];
   char     description[MAX_OBJ_DESC_LEN];
 
-  BACNET_ACTION_LIST actions[MAX_COMMAND_ACTIONS]; // TODO: make this dynamic?
+  // TODO: needed?
+  BACNET_ACTION_LIST actions[MAX_COMMAND_ACTIONS];
 } COMMAND_OBJECT;
 
 void command_init(void);
-uint32_t command_create(DEVICE_OBJECT_DATA* device, uint32_t instance, char* name);
+
+uint32_t command_create(
+  DEVICE_OBJECT_DATA* device,
+  uint32_t instance,
+  char* name,
+  char* description);
+
 bool command_update_status(COMMAND_OBJECT* object, bool successful);
 unsigned command_count(void);
 uint32_t command_index_to_instance(unsigned index);

--- a/src/object/command.h
+++ b/src/object/command.h
@@ -19,7 +19,6 @@ typedef struct {
   char     name[MAX_OBJ_NAME_LEN];
   char     description[MAX_OBJ_DESC_LEN];
 
-  // TODO: needed?
   BACNET_ACTION_LIST actions[MAX_COMMAND_ACTIONS];
 } COMMAND_OBJECT;
 

--- a/src/protocol/decode_call.c
+++ b/src/protocol/decode_call.c
@@ -282,6 +282,16 @@ static int decode_set_routed_multistate_input_value(
   return is_invalid ? -1 : 0;
 }
 
+static int
+decode_command_value(char* buffer, int* index, create_routed_command_t* data) {
+  bool is_invalid =
+    ei_decode_ulong(buffer, index, (unsigned long*)&data->value);
+
+  data->in_progress = true;
+
+  return is_invalid ? -1 : 0;
+}
+
 static int decode_create_routed_command(
   char* buffer,
   int* index,
@@ -300,7 +310,9 @@ static int decode_create_routed_command(
     || ei_get_type(buffer, index, &type, (int*)&size)
     || (size >= sizeof(data->description))
     || (memset(data->description, 0, sizeof(data->description)) == NULL)
-    || ei_decode_binary(buffer, index, data->description, &size);
+    || ei_decode_binary(buffer, index, data->description, &size)
+    || ei_get_type(buffer, index, &type, (int*)&size)
+    || type == ERL_ATOM_EXT ? 0 : decode_command_value(buffer, index, data);
 
   return is_invalid ? -1 : 0;
 }

--- a/src/protocol/decode_call.c
+++ b/src/protocol/decode_call.c
@@ -117,8 +117,10 @@ static int decode_call_type(char* buffer, int* index, uint8_t* type)
   }
 
   int enum_value = find_enum_value(BACNET_CALL_ATOMS, atom);
-  if (enum_value == -1)
+  if (enum_value == -1) {
+    *type = CALL_UNKNOWN;
     return -1;
+  }
 
   *type = enum_value;
 

--- a/src/protocol/decode_call.c
+++ b/src/protocol/decode_call.c
@@ -5,12 +5,14 @@
 #include "protocol/enum.h"
 
 const enum_tuple_t BACNET_CALL_ATOMS[] = {
-  {"create_gateway",                    0},
-  {"create_routed_device",              1},
-  {"create_routed_analog_input",        2},
-  {"set_routed_analog_input_value",     3},
-  {"create_routed_multistate_input",    4},
-  {"set_routed_multistate_input_value", 5},
+  {"create_gateway",                    CALL_CREATE_GATEWAY},
+  {"create_routed_device",              CALL_CREATE_ROUTED_DEVICE},
+  {"create_routed_analog_input",        CALL_CREATE_ROUTED_ANALOG_INPUT},
+  {"set_routed_analog_input_value",     CALL_SET_ROUTED_ANALOG_INPUT_VALUE},
+  {"create_routed_multistate_input",    CALL_CREATE_ROUTED_MULTISTATE_INPUT},
+  {"set_routed_multistate_input_value", CALL_SET_ROUTED_MULTISTATE_INPUT_VALUE},
+  {"create_routed_command",             CALL_CREATE_ROUTED_COMMAND},
+  {"set_routed_command_status",         CALL_SET_ROUTED_COMMAND_STATUS},
 };
 
 const size_t BACNET_CALL_SIZE_LOOKUP[] = {
@@ -20,6 +22,8 @@ const size_t BACNET_CALL_SIZE_LOOKUP[] = {
   sizeof(set_routed_analog_input_value_t),
   sizeof(create_routed_multistate_input_t),
   sizeof(set_routed_multistate_input_value_t),
+  sizeof(create_routed_command_t),
+  sizeof(set_routed_command_status_t),
 };
 
 static int decode_call_type(char* buffer, int* index, uint8_t* type);
@@ -276,6 +280,66 @@ static int decode_set_routed_multistate_input_value(
   return is_invalid ? -1 : 0;
 }
 
+static int decode_create_routed_command(
+  char* buffer,
+  int* index,
+  create_routed_command_t* data
+) {
+  long size = 0;
+  int  type = 0;
+
+  bool is_invalid =
+       ei_decode_ulong(buffer, index, (unsigned long*)&data->device_bacnet_id)
+    || ei_decode_ulong(buffer, index, (unsigned long*)&data->object_bacnet_id)
+    || ei_get_type(buffer, index, &type, (int*)&size)
+    || (size >= sizeof(data->name))
+    || (memset(data->name, 0, sizeof(data->name)) == NULL)
+    || ei_decode_binary(buffer, index, data->name, &size)
+    || ei_get_type(buffer, index, &type, (int*)&size)
+    || (size >= sizeof(data->description))
+    || (memset(data->description, 0, sizeof(data->description)) == NULL)
+    || ei_decode_binary(buffer, index, data->description, &size);
+
+  return is_invalid ? -1 : 0;
+}
+
+const enum_tuple_t BACNET_COMMAND_STATUS[] = {
+  {"succeeded", COMMAND_SUCCEEDED},
+  {"failed",    COMMAND_FAILED},
+};
+
+static int decode_command_status(
+  char* buffer,
+  int* index,
+  bacnet_command_status_t* status
+) {
+  char atom[MAXATOMLEN] = { 0 };
+
+  if (ei_decode_atom(buffer, index, atom) == -1)
+    return -1;
+
+  int enum_value = find_enum_value(BACNET_COMMAND_STATUS, atom);
+  if (enum_value == -1)
+    return -1;
+
+  *status = (bacnet_command_status_t)enum_value;
+
+  return 0;
+}
+
+static int decode_set_routed_command_status(
+  char* buffer,
+  int* index,
+  set_routed_command_status_t* data
+) {
+  bool is_invalid =
+       ei_decode_ulong(buffer, index, (unsigned long*)&data->device_bacnet_id)
+    || ei_decode_ulong(buffer, index, (unsigned long*)&data->object_bacnet_id)
+    || decode_command_status(buffer, index, &data->status);
+
+  return is_invalid ? -1 : 0;
+}
+
 static int decode_call_data(
   char* buffer,
   int* index,
@@ -300,6 +364,12 @@ static int decode_call_data(
 
     case CALL_SET_ROUTED_MULTISTATE_INPUT_VALUE:
       return decode_set_routed_multistate_input_value(buffer, index, data);
+
+    case CALL_CREATE_ROUTED_COMMAND:
+      return decode_create_routed_command(buffer, index, data);
+
+    case CALL_SET_ROUTED_COMMAND_STATUS:
+      return decode_set_routed_command_status(buffer, index, data);
 
     default:
       return -1;

--- a/src/protocol/decode_call.h
+++ b/src/protocol/decode_call.h
@@ -60,6 +60,8 @@ typedef struct {
   uint32_t object_bacnet_id;
   char     name[MAXATOMLEN];
   char     description[MAXATOMLEN];
+  uint32_t value;
+  bool     in_progress;
 } create_routed_command_t;
 
 typedef struct {

--- a/src/protocol/decode_call.h
+++ b/src/protocol/decode_call.h
@@ -4,14 +4,21 @@
 #include <bacnet/bacstr.h>
 
 typedef enum {
-  CALL_CREATE_GATEWAY = 0,
+  CALL_CREATE_GATEWAY,
   CALL_CREATE_ROUTED_DEVICE,
   CALL_CREATE_ROUTED_ANALOG_INPUT,
   CALL_SET_ROUTED_ANALOG_INPUT_VALUE,
   CALL_CREATE_ROUTED_MULTISTATE_INPUT,
   CALL_SET_ROUTED_MULTISTATE_INPUT_VALUE,
+  CALL_CREATE_ROUTED_COMMAND,
+  CALL_SET_ROUTED_COMMAND_STATUS,
   CALL_UNKNOWN = 255,
 } __attribute__((packed)) bacnet_call_type_t;
+
+typedef enum {
+  COMMAND_SUCCEEDED,
+  COMMAND_FAILED,
+} bacnet_command_status_t;
 
 typedef struct {
   uint32_t                bacnet_id;
@@ -47,6 +54,20 @@ typedef struct {
   uint32_t object_bacnet_id;
   uint8_t  value;
 } set_routed_multistate_input_value_t;
+
+typedef struct {
+  uint32_t device_bacnet_id;
+  uint32_t object_bacnet_id;
+  char     name[MAXATOMLEN];
+  char     description[MAXATOMLEN];
+} create_routed_command_t;
+
+typedef struct {
+  uint32_t device_bacnet_id;
+  uint32_t object_bacnet_id;
+
+  bacnet_command_status_t status;
+} set_routed_command_status_t;
 
 int bacnet_call_malloc(bacnet_call_type_t type, void** call);
 

--- a/src/protocol/event.c
+++ b/src/protocol/event.c
@@ -1,0 +1,22 @@
+#include "protocol/event.h"
+#include "port.h"
+
+int cast_command(
+  uint32_t device_instance,
+  uint32_t object_instance,
+  uint32_t value
+) {
+  ei_x_buff reply;
+  ei_x_new_with_version(&reply);
+  ei_x_encode_tuple_header(&reply, 2);
+  ei_x_encode_atom(&reply, "$gen_cast");
+
+  // {:command, device_id, object_id, value}
+  ei_x_encode_tuple_header(&reply, 4);
+  ei_x_encode_atom(&reply, "command");
+  ei_x_encode_ulong(&reply, device_instance);
+  ei_x_encode_ulong(&reply, object_instance);
+  ei_x_encode_ulong(&reply, value);
+
+  return port_send(&reply);
+}

--- a/src/protocol/event.c
+++ b/src/protocol/event.c
@@ -1,7 +1,7 @@
 #include "protocol/event.h"
 #include "port.h"
 
-int cast_command(
+int send_command(
   uint32_t device_instance,
   uint32_t object_instance,
   uint32_t value
@@ -9,7 +9,7 @@ int cast_command(
   ei_x_buff reply;
   ei_x_new_with_version(&reply);
   ei_x_encode_tuple_header(&reply, 2);
-  ei_x_encode_atom(&reply, "$gen_cast");
+  ei_x_encode_atom(&reply, "$event");
 
   // {:command, device_id, object_id, value}
   ei_x_encode_tuple_header(&reply, 4);

--- a/src/protocol/event.h
+++ b/src/protocol/event.h
@@ -1,0 +1,11 @@
+#ifndef BACNET_EVENT_H
+#define BACNET_EVENT_H
+
+#include <ei.h>
+
+int cast_command(
+  uint32_t device_instance,
+  uint32_t object_instance,
+  uint32_t value);
+
+#endif /* BACNET_EVENT_H */

--- a/src/protocol/event.h
+++ b/src/protocol/event.h
@@ -3,7 +3,7 @@
 
 #include <ei.h>
 
-int cast_command(
+int send_command(
   uint32_t device_instance,
   uint32_t object_instance,
   uint32_t value);


### PR DESCRIPTION
Adds ability to create Command objects with basic properties. The `bacnetd` will fire events when it receives a Command(ed) change from the BMS. It is the responsibility of the owning process to update the status of the command when appropriate.