### PR TITLE
Fix invalid object-identifier response for read-property request

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,8 @@ else()
         patches/0004-Add-configurable-vendor-name-support.patch
         patches/0005-Add-routed-analog-input-object-support.patch
         patches/0006-Add-routed-multistate-input-object-support.patch
-        patches/0007-Allow-BACNET_PROTOCOL_REVISION-to-be-set-by-user.patch)
+        patches/0007-Allow-BACNET_PROTOCOL_REVISION-to-be-set-by-user.patch
+        patches/0008-Exclude-object-identifier-from-the-common-prop-list.patch)
 endif()
 
 CPMFindPackage(

--- a/patches/0008-Exclude-object-identifier-from-the-common-prop-list.patch
+++ b/patches/0008-Exclude-object-identifier-from-the-common-prop-list.patch
@@ -1,0 +1,41 @@
+From 2cf6d05fed85e334189063fbf0c59fb3cd972616 Mon Sep 17 00:00:00 2001
+From: abelino <abelino.romo@gmail.com>
+Date: Tue, 8 Apr 2025 21:08:36 -0700
+Subject: [PATCH] Exclude object-identifier from the common prop-list when
+ routing is enabled
+
+---
+ src/bacnet/basic/service/h_whois.c | 2 +-
+ src/bacnet/proplist.c              | 2 ++
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/bacnet/basic/service/h_whois.c b/src/bacnet/basic/service/h_whois.c
+index 27656697..f2c99d02 100644
+--- a/src/bacnet/basic/service/h_whois.c
++++ b/src/bacnet/basic/service/h_whois.c
+@@ -125,7 +125,7 @@ static void check_who_is_for_routing(
+     bcast_net.net = BACNET_BROADCAST_NETWORK; /* That's all we have to set */
+ 
+     while (Routed_Device_GetNext(&bcast_net, my_list, &cursor)) {
+-        dev_instance = Device_Object_Instance_Number();
++        dev_instance = Routed_Device_Index_To_Instance(cursor);
+         if (dev_instance == 0) continue;
+ 
+         /* If len == 0, no limits and always respond */
+diff --git a/src/bacnet/proplist.c b/src/bacnet/proplist.c
+index ed6524ab..2461c589 100644
+--- a/src/bacnet/proplist.c
++++ b/src/bacnet/proplist.c
+@@ -324,7 +324,9 @@ bool property_list_common(BACNET_PROPERTY_ID property)
+     bool status = false;
+ 
+     switch (property) {
++#ifndef BAC_ROUTING
+         case PROP_OBJECT_IDENTIFIER:
++#endif
+         case PROP_OBJECT_TYPE:
+             status = true;
+             break;
+-- 
+2.48.1
+


### PR DESCRIPTION
When a read-property request is received, the `Device_Read_Property` function processes two common properties: object-identifier and object-type. However, the `property_list_common_encode` function currently uses the default device bacnet_id, which is incorrect in routing scenarios. With this change, if the bacnet-stack is compiled with the `BAC_ROUTING` option, the object-identifier is omitted from the common list, allowing the downstream read-property subroutine to handle it appropriately.