### PR TITLE
Add sentinel value to terminate the SUPPORTED_OBJECT_TABLE

### DIFF
--- a/src/bacnet.c
+++ b/src/bacnet.c
@@ -355,6 +355,10 @@ static object_functions_t SUPPORTED_OBJECT_TABLE[] = {
     .Object_Delete = NULL,
     .Object_Timer = NULL,
   },
+  {
+    // Sentinel value to terminate the list.
+    .Object_Type = MAX_BACNET_OBJECT_TYPE
+  }
 };
 
 static int init_service_handlers()


### PR DESCRIPTION
Because of how the bacnet-stack works, it is recommended to terminate the `SUPPORTED_OBJECT_TABLE` with a sentinel value that indicates the end.

Steve Karg's usual way is to set the last value of the list to a value completely null with the exception of the type in which is set `MAX_BACNET_OBJECT_TYPE`. See [bacnet-stack `device.c` as an example of this](https://github.com/bacnet-stack/bacnet-stack/blob/980c78dddbd849c7ff8436f317058c7905213f6d/src/bacnet/basic/object/device.c#L389). There the other values are set to `NULL`, but the only value required because it is normally the first one to be checked is the type.

This change is to make your BACnet application more robust, because depending of the system and the compilation, it can causes issues, like segmentation faults (@BACnetEd, fix me if I am wrong or something additional to comment).

**Note**: as it is a small change, we prefer to keep it simple and clean. This commit is done in a branch with the latest of your `main` branch.