### PR TITLE
Fix switch cases with the error ""a label can only be part of a statement and a declaration is not a statement"

### DIFF
--- a/src/object/binary_input.c
+++ b/src/object/binary_input.c
@@ -236,16 +236,20 @@ int binary_input_read_property(BACNET_READ_PROPERTY_DATA* data)
       break;
 
     case PROP_OBJECT_NAME:
+    {
       BACNET_CHARACTER_STRING name;
       binary_input_name(data->object_instance, &name);
       apdu_len = encode_application_character_string(&apdu[0], &name);
       break;
+    }
 
     case PROP_DESCRIPTION:
+    {
       BACNET_CHARACTER_STRING description;
       binary_input_description(object, &description);
       apdu_len = encode_application_character_string(&apdu[0], &description);
       break;
+    }
 
     case PROP_OBJECT_TYPE:
       apdu_len =
@@ -261,18 +265,23 @@ int binary_input_read_property(BACNET_READ_PROPERTY_DATA* data)
       break;
 
     case PROP_ACTIVE_TEXT:
+    {
       BACNET_CHARACTER_STRING active_text;
       binary_input_active_text(object, &active_text);
       apdu_len = encode_application_character_string(&apdu[0], &active_text);
       break;
+    }
 
     case PROP_INACTIVE_TEXT:
+    {
       BACNET_CHARACTER_STRING inactive_text;
       binary_input_inactive_text(object, &inactive_text);
       apdu_len = encode_application_character_string(&apdu[0], &inactive_text);
       break;
+    }
 
     case PROP_STATUS_FLAGS:
+    {
       BACNET_BIT_STRING status;
       bitstring_init(&status);
 
@@ -283,6 +292,7 @@ int binary_input_read_property(BACNET_READ_PROPERTY_DATA* data)
 
       apdu_len = encode_application_bitstring(&apdu[0], &status);
       break;
+    }
 
     case PROP_EVENT_STATE:
       apdu_len = encode_application_enumerated(&apdu[0], EVENT_STATE_NORMAL);

--- a/src/object/characterstring_value.c
+++ b/src/object/characterstring_value.c
@@ -225,16 +225,20 @@ int characterstring_value_read_property(BACNET_READ_PROPERTY_DATA* data)
       break;
 
     case PROP_OBJECT_NAME:
+    {
       BACNET_CHARACTER_STRING name;
       characterstring_value_name(data->object_instance, &name);
       apdu_len = encode_application_character_string(&apdu[0], &name);
       break;
+    }
 
     case PROP_DESCRIPTION:
+    {
       BACNET_CHARACTER_STRING description;
       characterstring_value_description(object, &description);
       apdu_len = encode_application_character_string(&apdu[0], &description);
       break;
+    }
 
     case PROP_OBJECT_TYPE:
       apdu_len =
@@ -242,12 +246,15 @@ int characterstring_value_read_property(BACNET_READ_PROPERTY_DATA* data)
       break;
 
     case PROP_PRESENT_VALUE:
+    {
       BACNET_CHARACTER_STRING present_value;
       characterstring_value_present_value(object, &present_value);
       apdu_len = encode_application_character_string(&apdu[0], &present_value);
       break;
+    }
 
     case PROP_STATUS_FLAGS:
+    {
       BACNET_BIT_STRING status;
       bitstring_init(&status);
 
@@ -258,6 +265,7 @@ int characterstring_value_read_property(BACNET_READ_PROPERTY_DATA* data)
 
       apdu_len = encode_application_bitstring(&apdu[0], &status);
       break;
+    }
 
     case PROP_EVENT_STATE:
       apdu_len = encode_application_enumerated(&apdu[0], EVENT_STATE_NORMAL);

--- a/src/object/command.c
+++ b/src/object/command.c
@@ -268,16 +268,20 @@ int command_read_property(BACNET_READ_PROPERTY_DATA* data)
       break;
 
     case PROP_OBJECT_NAME:
+    {
       BACNET_CHARACTER_STRING name;
       command_name(instance, &name);
       apdu_len = encode_application_character_string(&apdu[0], &name);
       break;
+    }
 
     case PROP_DESCRIPTION:
+    {
       BACNET_CHARACTER_STRING description;
       command_description(object, &description);
       apdu_len = encode_application_character_string(&apdu[0], &description);
       break;
+    }
 
     case PROP_OBJECT_TYPE:
       apdu_len = encode_application_enumerated(&apdu[0], OBJECT_COMMAND);
@@ -416,6 +420,7 @@ bool command_write_property(BACNET_WRITE_PROPERTY_DATA* data)
 
       return sent_ret == 0;
     default:
+    {
       bool is_valid_prop =
         property_lists_member(
           required_properties,
@@ -433,6 +438,7 @@ bool command_write_property(BACNET_WRITE_PROPERTY_DATA* data)
         data->error_code  = ERROR_CODE_UNKNOWN_PROPERTY;
       }
       break;
+    }
   }
 
   return false;


### PR DESCRIPTION
This error was being given on some switches statements and produces errors that avoid to compile the code depending of the compiler.

As the idea is to have something robust and it is an easy fix, I think it can be better to have it implemented. Another thing would be if it will be better to standardize all cases with curly braces.

This branch has been created from your latest main, although the fix is already integrated in all our branches.

Anyway, an example of the error given while trying to compile is this one:

```
.../bacnet_ex/src/object/binary_input.c: In function ‘binary_input_read_property’:
.../bacnet_ex/src/object/binary_input.c:239:7: error: a label can only be part of a statement and a declaration is not a statement
  239 |       BACNET_CHARACTER_STRING name;
      |       ^~~~~~~~~~~~~~~~~~~~~~~
.../bacnet_ex/src/object/binary_input.c:245:7: error: a label can only be part of a statement and a declaration is not a statement
  245 |       BACNET_CHARACTER_STRING description;
      |       ^~~~~~~~~~~~~~~~~~~~~~~
.../bacnet_ex/src/object/binary_input.c:264:7: error: a label can only be part of a statement and a declaration is not a statement
  264 |       BACNET_CHARACTER_STRING active_text;
      |       ^~~~~~~~~~~~~~~~~~~~~~~
.../bacnet_ex/src/object/binary_input.c:270:7: error: a label can only be part of a statement and a declaration is not a statement
  270 |       BACNET_CHARACTER_STRING inactive_text;
      |       ^~~~~~~~~~~~~~~~~~~~~~~
.../bacnet_ex/src/object/binary_input.c:276:7: error: a label can only be part of a statement and a declaration is not a statement
  276 |       BACNET_BIT_STRING status;
      |       ^~~~~~~~~~~~~~~~~
```